### PR TITLE
use new sonner shadcn ui component

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,7 +5,7 @@ import { fontHeading, fontMono, fontSans } from "@/lib/fonts";
 import { cn } from "@/lib/utils";
 import "@/styles/globals.css";
 import type { Metadata, Viewport } from "next";
-import { Toaster } from "sonner";
+import { Toaster } from "@/components/ui/sonner";
 
 export const viewport: Viewport = {
   colorScheme: "light dark",
@@ -79,7 +79,7 @@ export default function RootLayout({
         <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
           {children}
           <TailwindIndicator />
-          <Toaster richColors />
+          <Toaster />
         </ThemeProvider>
       </body>
     </html>

--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -1,0 +1,31 @@
+"use client"
+
+import { useTheme } from "next-themes"
+import { Toaster as Sonner } from "sonner"
+
+type ToasterProps = React.ComponentProps<typeof Sonner>
+
+const Toaster = ({ ...props }: ToasterProps) => {
+  const { theme = "system" } = useTheme()
+
+  return (
+    <Sonner
+      theme={theme as ToasterProps["theme"]}
+      className="toaster group"
+      toastOptions={{
+        classNames: {
+          toast:
+            "group toast group-[.toaster]:bg-background group-[.toaster]:text-foreground group-[.toaster]:border-border group-[.toaster]:shadow-lg",
+          description: "group-[.toast]:text-muted-foreground",
+          actionButton:
+            "group-[.toast]:bg-primary group-[.toast]:text-primary-foreground",
+          cancelButton:
+            "group-[.toast]:bg-muted group-[.toast]:text-muted-foreground",
+        },
+      }}
+      {...props}
+    />
+  )
+}
+
+export { Toaster }


### PR DESCRIPTION


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request modifies the import path of the `Toaster` component and adds a new `Toaster` component in `src/components/ui/sonner.tsx` with theme support.
> 
> ## What changed
> - The import path of `Toaster` in `src/app/layout.tsx` has been changed from `sonner` to `@/components/ui/sonner`.
> - A new `Toaster` component has been added in `src/components/ui/sonner.tsx`. This component uses the `useTheme` hook from `next-themes` to get the current theme and passes it to the `Sonner` component from `sonner`. It also provides custom class names for different parts of the toast based on the current theme.
> 
> ## How to test
> - Pull the changes from this pull request.
> - Run the application and trigger a toast notification. The toast should appear with the correct styles based on the current theme.
> - Change the theme and trigger another toast. The toast should now appear with the correct styles for the new theme.
> 
> ## Why make this change
> This change allows the `Toaster` component to support different themes, making it more versatile and improving the user experience. The custom class names allow for more control over the appearance of the toast notifications.
</details>